### PR TITLE
Use `=` instead of `==` for equality check

### DIFF
--- a/lib/git-resolve-conflict.sh
+++ b/lib/git-resolve-conflict.sh
@@ -4,7 +4,7 @@ git-resolve-conflict() {
   STRATEGY="$1"
   FILE_PATH="$2"
 
-  if [ "$1" == "--version" ]; then
+  if [ "$1" = "--version" ]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     cat $DIR/../package.json | grep version | sed 's/,//'
     return


### PR DESCRIPTION
AFAIK `=` is the more portable version for shells other than `bash`. This versions works for me on `zsh` but `==` does not.